### PR TITLE
Lock dashboard boundary behavior with BVA regression coverage

### DIFF
--- a/controllers/menu_analytics_controller.py
+++ b/controllers/menu_analytics_controller.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 
@@ -16,11 +16,14 @@ router = APIRouter(
 )
 @router.get("/top-items")
 def top_menu_items(
-    limit: int = 10,
+    limit: int = Query(default=10, ge=1, le=100),
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
     require_roles(current_user, ["owner", "staff"])
+
+    if not 1 <= limit <= 100:
+        raise HTTPException(status_code=422, detail="limit must be between 1 and 100")
 
     rows = (
         db.query(
@@ -82,11 +85,14 @@ def menu_revenue(
     ]
 @router.get("/trends")
 def menu_trends(
-    menu_item_id: str,
+    menu_item_id: str = Query(..., min_length=1),
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
     require_roles(current_user, ["owner", "staff"])
+
+    if not menu_item_id:
+        raise HTTPException(status_code=422, detail="menu_item_id must not be empty")
 
     rows = (
         db.query(

--- a/controllers/menu_analytics_controller.py
+++ b/controllers/menu_analytics_controller.py
@@ -1,24 +1,32 @@
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy.orm import Session
 from sqlalchemy import func
+from sqlalchemy.orm import Session
 
 from db.database import get_db
+from models.menu_item import MenuItem
+from models.order import Order
+from models.order_line import OrderLine
+from models.user import User
 from utils.dependencies import get_current_user
 from utils.permissions import require_roles
 
-from models.order import Order
-from models.order_line import OrderLine
-from models.menu_item import MenuItem
+DbSession = Annotated[Session, Depends(get_db)]
+CurrentUser = Annotated[User, Depends(get_current_user)]
+VALIDATION_ERROR_RESPONSE = {422: {"description": "Validation Error"}}
 
 router = APIRouter(
     prefix="/dashboard/menu",
-    tags=["Dashboard - Menu Analytics"]
+    tags=["Dashboard - Menu Analytics"],
 )
-@router.get("/top-items")
+
+
+@router.get("/top-items", responses=VALIDATION_ERROR_RESPONSE)
 def top_menu_items(
-    limit: int = Query(default=10, ge=1, le=100),
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    db: DbSession,
+    current_user: CurrentUser,
+    limit: Annotated[int, Query(ge=1, le=100)] = 10,
 ):
     require_roles(current_user, ["owner", "staff"])
 
@@ -46,17 +54,19 @@ def top_menu_items(
 
     return [
         {
-            "menu_item_id": r.menu_item_id,
-            "name": r.menu_name,
-            "sold_qty": int(r.total_qty or 0),
-            "revenue": float(r.revenue or 0),
+            "menu_item_id": row.menu_item_id,
+            "name": row.menu_name,
+            "sold_qty": int(row.total_qty or 0),
+            "revenue": float(row.revenue or 0),
         }
-        for r in rows
+        for row in rows
     ]
+
+
 @router.get("/revenue")
 def menu_revenue(
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    db: DbSession,
+    current_user: CurrentUser,
 ):
     require_roles(current_user, ["owner", "staff"])
 
@@ -78,16 +88,18 @@ def menu_revenue(
 
     return [
         {
-            "name": r.menu_name,
-            "revenue": float(r.revenue or 0),
+            "name": row.menu_name,
+            "revenue": float(row.revenue or 0),
         }
-        for r in rows
+        for row in rows
     ]
-@router.get("/trends")
+
+
+@router.get("/trends", responses=VALIDATION_ERROR_RESPONSE)
 def menu_trends(
-    menu_item_id: str = Query(..., min_length=1),
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    menu_item_id: Annotated[str, Query(min_length=1)],
+    db: DbSession,
+    current_user: CurrentUser,
 ):
     require_roles(current_user, ["owner", "staff"])
 
@@ -112,8 +124,8 @@ def menu_trends(
 
     return [
         {
-            "date": r.day.date().isoformat(),
-            "sold_qty": int(r.sold_qty or 0),
+            "date": row.day.date().isoformat(),
+            "sold_qty": int(row.sold_qty or 0),
         }
-        for r in rows
+        for row in rows
     ]

--- a/controllers/point_dashboard_controller.py
+++ b/controllers/point_dashboard_controller.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 
@@ -49,11 +49,14 @@ def point_summary(
     }
 @router.get("/top-customers")
 def top_customers_by_points(
-    limit: int = 10,
+    limit: int = Query(default=10, ge=1, le=100),
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
     require_roles(current_user, ["owner", "staff"])
+
+    if not 1 <= limit <= 100:
+        raise HTTPException(status_code=422, detail="limit must be between 1 and 100")
 
     rows = (
         db.query(

--- a/controllers/point_dashboard_controller.py
+++ b/controllers/point_dashboard_controller.py
@@ -1,24 +1,31 @@
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy.orm import Session
 from sqlalchemy import func
+from sqlalchemy.orm import Session
 
 from db.database import get_db
+from models.order import Order
+from models.point_transaction import PointTransaction
+from models.user import User
+from models.user_point import UserPoint
 from utils.dependencies import get_current_user
 from utils.permissions import require_roles
 
-from models.user_point import UserPoint
-from models.point_transaction import PointTransaction
-from models.order import Order
-from models.user import User
+DbSession = Annotated[Session, Depends(get_db)]
+CurrentUser = Annotated[User, Depends(get_current_user)]
+VALIDATION_ERROR_RESPONSE = {422: {"description": "Validation Error"}}
 
 router = APIRouter(
     prefix="/dashboard/points",
-    tags=["Dashboard - Loyalty Points"]
+    tags=["Dashboard - Loyalty Points"],
 )
+
+
 @router.get("/summary")
 def point_summary(
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    db: DbSession,
+    current_user: CurrentUser,
 ):
     require_roles(current_user, ["owner", "staff"])
 
@@ -47,11 +54,13 @@ def point_summary(
         "total_points_issued": total_points,
         "total_customers_with_points": total_customers,
     }
-@router.get("/top-customers")
+
+
+@router.get("/top-customers", responses=VALIDATION_ERROR_RESPONSE)
 def top_customers_by_points(
-    limit: int = Query(default=10, ge=1, le=100),
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    db: DbSession,
+    current_user: CurrentUser,
+    limit: Annotated[int, Query(ge=1, le=100)] = 10,
 ):
     require_roles(current_user, ["owner", "staff"])
 
@@ -78,16 +87,18 @@ def top_customers_by_points(
 
     return [
         {
-            "user_id": r.id,
-            "name": r.display_name or r.email,
-            "total_points": r.total_points,
+            "user_id": row.id,
+            "name": row.display_name or row.email,
+            "total_points": row.total_points,
         }
-        for r in rows
+        for row in rows
     ]
+
+
 @router.get("/transactions")
 def point_transactions(
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    db: DbSession,
+    current_user: CurrentUser,
 ):
     require_roles(current_user, ["owner", "staff"])
 
@@ -113,11 +124,11 @@ def point_transactions(
 
     return [
         {
-            "transaction_id": r.id,
-            "order_id": r.order_id,
-            "customer": r.display_name or r.email,
-            "points": r.points,
-            "created_at": r.created_at.isoformat(),
+            "transaction_id": row.id,
+            "order_id": row.order_id,
+            "customer": row.display_name or row.email,
+            "points": row.points,
+            "created_at": row.created_at.isoformat(),
         }
-        for r in rows
+        for row in rows
     ]

--- a/controllers/review_dashboard_controller.py
+++ b/controllers/review_dashboard_controller.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends, Query
+from datetime import date, datetime, time, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 
@@ -53,14 +55,23 @@ def review_summary(
     }
 @router.get("")
 def list_reviews(
-    rating: int | None = Query(default=None),
-    menu_item_id: str | None = Query(default=None),
-    from_date: str | None = Query(default=None),
-    to_date: str | None = Query(default=None),
+    rating: int | None = Query(default=None, ge=1, le=5),
+    menu_item_id: str | None = Query(default=None, min_length=1),
+    from_date: date | None = Query(default=None),
+    to_date: date | None = Query(default=None),
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
     require_roles(current_user, ["owner", "staff"])
+
+    if rating is not None and not 1 <= rating <= 5:
+        raise HTTPException(status_code=422, detail="rating must be between 1 and 5")
+
+    if menu_item_id == "":
+        raise HTTPException(status_code=422, detail="menu_item_id must not be empty")
+
+    if from_date and to_date and from_date > to_date:
+        raise HTTPException(status_code=422, detail="from_date must be before or equal to to_date")
 
     q = (
         db.query(
@@ -75,7 +86,7 @@ def list_reviews(
     )
 
     # Filter theo số sao
-    if rating:
+    if rating is not None:
         q = q.filter(MenuItemReview.rating == rating)
 
     # Filter theo món
@@ -84,10 +95,14 @@ def list_reviews(
 
     # Filter theo thời gian
     if from_date:
-        q = q.filter(MenuItemReview.created_at >= from_date)
+        q = q.filter(
+            MenuItemReview.created_at >= datetime.combine(from_date, time.min)
+        )
 
     if to_date:
-        q = q.filter(MenuItemReview.created_at <= to_date)
+        q = q.filter(
+            MenuItemReview.created_at < datetime.combine(to_date + timedelta(days=1), time.min)
+        )
 
     rows = q.order_by(MenuItemReview.created_at.desc()).limit(100).all()
 

--- a/controllers/review_dashboard_controller.py
+++ b/controllers/review_dashboard_controller.py
@@ -1,25 +1,31 @@
 from datetime import date, datetime, time, timedelta
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy.orm import Session
 from sqlalchemy import func
+from sqlalchemy.orm import Session
 
 from db.database import get_db
+from models.menu_item import MenuItem
+from models.review import MenuItemReview
+from models.user import User
 from utils.dependencies import get_current_user
 from utils.permissions import require_roles
 
-from models.review import MenuItemReview
-from models.menu_item import MenuItem
-from models.order import Order
+DbSession = Annotated[Session, Depends(get_db)]
+CurrentUser = Annotated[User, Depends(get_current_user)]
+VALIDATION_ERROR_RESPONSE = {422: {"description": "Validation Error"}}
 
 router = APIRouter(
     prefix="/dashboard/reviews",
-    tags=["Dashboard - Reviews"]
+    tags=["Dashboard - Reviews"],
 )
+
+
 @router.get("/summary")
 def review_summary(
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    db: DbSession,
+    current_user: CurrentUser,
 ):
     require_roles(current_user, ["owner", "staff"])
 
@@ -53,14 +59,16 @@ def review_summary(
         "avg_rating": round(float(avg_rating), 2),
         "bad_reviews": bad_reviews,
     }
-@router.get("")
+
+
+@router.get("", responses=VALIDATION_ERROR_RESPONSE)
 def list_reviews(
-    rating: int | None = Query(default=None, ge=1, le=5),
-    menu_item_id: str | None = Query(default=None, min_length=1),
-    from_date: date | None = Query(default=None),
-    to_date: date | None = Query(default=None),
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    db: DbSession,
+    current_user: CurrentUser,
+    rating: Annotated[int | None, Query(ge=1, le=5)] = None,
+    menu_item_id: Annotated[str | None, Query(min_length=1)] = None,
+    from_date: Annotated[date | None, Query()] = None,
+    to_date: Annotated[date | None, Query()] = None,
 ):
     require_roles(current_user, ["owner", "staff"])
 
@@ -73,7 +81,7 @@ def list_reviews(
     if from_date and to_date and from_date > to_date:
         raise HTTPException(status_code=422, detail="from_date must be before or equal to to_date")
 
-    q = (
+    query = (
         db.query(
             MenuItemReview.id,
             MenuItemReview.rating,
@@ -85,41 +93,40 @@ def list_reviews(
         .filter(MenuItem.restaurant_id == current_user.restaurant_id)
     )
 
-    # Filter theo số sao
     if rating is not None:
-        q = q.filter(MenuItemReview.rating == rating)
+        query = query.filter(MenuItemReview.rating == rating)
 
-    # Filter theo món
     if menu_item_id:
-        q = q.filter(MenuItemReview.menu_item_id == menu_item_id)
+        query = query.filter(MenuItemReview.menu_item_id == menu_item_id)
 
-    # Filter theo thời gian
     if from_date:
-        q = q.filter(
+        query = query.filter(
             MenuItemReview.created_at >= datetime.combine(from_date, time.min)
         )
 
     if to_date:
-        q = q.filter(
+        query = query.filter(
             MenuItemReview.created_at < datetime.combine(to_date + timedelta(days=1), time.min)
         )
 
-    rows = q.order_by(MenuItemReview.created_at.desc()).limit(100).all()
+    rows = query.order_by(MenuItemReview.created_at.desc()).limit(100).all()
 
     return [
         {
-            "review_id": r.id,
-            "menu_item": r.menu_name,
-            "rating": r.rating,
-            "comment": r.comment,
-            "created_at": r.created_at.isoformat(),
+            "review_id": row.id,
+            "menu_item": row.menu_name,
+            "rating": row.rating,
+            "comment": row.comment,
+            "created_at": row.created_at.isoformat(),
         }
-        for r in rows
+        for row in rows
     ]
+
+
 @router.get("/by-menu")
 def reviews_by_menu(
-    db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    db: DbSession,
+    current_user: CurrentUser,
 ):
     require_roles(current_user, ["owner", "staff"])
 
@@ -139,10 +146,10 @@ def reviews_by_menu(
 
     return [
         {
-            "menu_item_id": r.menu_item_id,
-            "menu_item": r.name,
-            "total_reviews": r.total_reviews,
-            "avg_rating": round(float(r.avg_rating), 2),
+            "menu_item_id": row.menu_item_id,
+            "menu_item": row.name,
+            "total_reviews": row.total_reviews,
+            "avg_rating": round(float(row.avg_rating), 2),
         }
-        for r in rows
+        for row in rows
     ]

--- a/tests/unit/test_dashboard_and_reports.py
+++ b/tests/unit/test_dashboard_and_reports.py
@@ -1,7 +1,8 @@
-from datetime import datetime
+from datetime import date, datetime
 from types import SimpleNamespace
 
-from fastapi import Request
+import pytest
+from fastapi import HTTPException, Request
 
 from controllers.customer_dashboard_controller import list_customers
 from controllers.menu_analytics_controller import menu_revenue, menu_trends, top_menu_items
@@ -188,7 +189,7 @@ def test_point_dashboard_endpoints_transform_rows():
         "total_points_issued": 500,
         "total_customers_with_points": 7,
     }
-    assert top_customers_by_points(db=top_db, current_user=owner_user()) == [
+    assert top_customers_by_points(limit=10, db=top_db, current_user=owner_user()) == [
         {"user_id": "user-1", "name": "Top User", "total_points": 900}
     ]
     assert point_transactions(db=tx_db, current_user=owner_user()) == [
@@ -248,8 +249,8 @@ def test_review_dashboard_endpoints_transform_rows():
     assert list_reviews(
         rating=5,
         menu_item_id="menu-1",
-        from_date="2026-03-01",
-        to_date="2026-03-31",
+        from_date=date(2026, 3, 1),
+        to_date=date(2026, 3, 31),
         db=list_db,
         current_user=owner_user(),
     ) == [
@@ -301,7 +302,7 @@ def test_menu_analytics_endpoints_transform_rows():
         ]
     )
 
-    assert top_menu_items(db=top_db, current_user=owner_user()) == [
+    assert top_menu_items(limit=10, db=top_db, current_user=owner_user()) == [
         {
             "menu_item_id": "menu-1",
             "name": "Pho",
@@ -386,3 +387,129 @@ def test_overview_report_handles_options_and_cached_path(monkeypatch):
 
     assert overview_report(make_request("OPTIONS"), current_user=user) == {}
     assert overview_report(make_request("GET"), current_user=user) == {"ok": True}
+
+
+def test_dashboard_limit_bva_accepts_min_and_max_values():
+    point_limit_min = QueryStub(all_value=[])
+    point_limit_max = QueryStub(all_value=[])
+    menu_limit_min = QueryStub(all_value=[])
+    menu_limit_max = QueryStub(all_value=[])
+
+    assert top_customers_by_points(
+        limit=1,
+        db=DBSequence([point_limit_min]),
+        current_user=owner_user(),
+    ) == []
+    assert point_limit_min.limit_value == 1
+
+    assert top_customers_by_points(
+        limit=100,
+        db=DBSequence([point_limit_max]),
+        current_user=owner_user(),
+    ) == []
+    assert point_limit_max.limit_value == 100
+
+    assert top_menu_items(
+        limit=1,
+        db=DBSequence([menu_limit_min]),
+        current_user=owner_user(),
+    ) == []
+    assert menu_limit_min.limit_value == 1
+
+    assert top_menu_items(
+        limit=100,
+        db=DBSequence([menu_limit_max]),
+        current_user=owner_user(),
+    ) == []
+    assert menu_limit_max.limit_value == 100
+
+
+def test_dashboard_limit_bva_rejects_values_outside_range():
+    for limit in (0, 101):
+        with pytest.raises(HTTPException) as point_exc:
+            top_customers_by_points(
+                limit=limit,
+                db=DBSequence([]),
+                current_user=owner_user(),
+            )
+
+        assert point_exc.value.status_code == 422
+        assert point_exc.value.detail == "limit must be between 1 and 100"
+
+        with pytest.raises(HTTPException) as menu_exc:
+            top_menu_items(
+                limit=limit,
+                db=DBSequence([]),
+                current_user=owner_user(),
+            )
+
+        assert menu_exc.value.status_code == 422
+        assert menu_exc.value.detail == "limit must be between 1 and 100"
+
+
+def test_review_dashboard_rating_bva_accepts_1_and_5_only_within_range():
+    for rating in (1, 5):
+        assert list_reviews(
+            rating=rating,
+            menu_item_id=None,
+            from_date=None,
+            to_date=None,
+            db=DBSequence([QueryStub(all_value=[])]),
+            current_user=owner_user(),
+        ) == []
+
+    for rating in (0, 6):
+        with pytest.raises(HTTPException) as exc_info:
+            list_reviews(
+                rating=rating,
+                menu_item_id=None,
+                from_date=None,
+                to_date=None,
+                db=DBSequence([]),
+                current_user=owner_user(),
+            )
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail == "rating must be between 1 and 5"
+
+
+def test_review_dashboard_date_range_bva_allows_same_day_and_rejects_inversion():
+    assert list_reviews(
+        rating=None,
+        menu_item_id=None,
+        from_date=date(2026, 3, 31),
+        to_date=date(2026, 3, 31),
+        db=DBSequence([QueryStub(all_value=[])]),
+        current_user=owner_user(),
+    ) == []
+
+    with pytest.raises(HTTPException) as exc_info:
+        list_reviews(
+            rating=None,
+            menu_item_id=None,
+            from_date=date(2026, 4, 1),
+            to_date=date(2026, 3, 31),
+            db=DBSequence([]),
+            current_user=owner_user(),
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "from_date must be before or equal to to_date"
+
+
+def test_menu_trends_menu_item_id_bva_rejects_empty_and_accepts_single_character():
+    assert menu_trends(
+        menu_item_id="m",
+        db=DBSequence([QueryStub(all_value=[])]),
+        current_user=owner_user(),
+    ) == []
+
+    with pytest.raises(HTTPException) as exc_info:
+        menu_trends(
+            menu_item_id="",
+            db=DBSequence([]),
+            current_user=owner_user(),
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "menu_item_id must not be empty"


### PR DESCRIPTION
Dashboard endpoints accepted edge-case inputs without explicit controller-level guards, so the change adds clear boundary validation and focused regression coverage for limit, rating, menu_item_id, and review date ranges.

The tests stay in the existing dashboard unit suite and reuse the current DB stubs to keep the diff reviewable and avoid coupling this work to the broader HTTP app bootstrap path.

Constraint: Keep the change scoped to dashboard APIs in a mixed worktree
Rejected: Add HTTP-level TestClient coverage for these cases | request path hung in the current test environment and would make the suite flaky
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: If dashboard query bounds change later, update both controller guards and the BVA suite together
Tested: ./.venv/bin/ruff check controllers/point_dashboard_controller.py controllers/menu_analytics_controller.py controllers/review_dashboard_controller.py tests/unit/test_dashboard_and_reports.py
Tested: ./.venv/bin/pytest tests/unit/test_dashboard_and_reports.py
Not-tested: Full repository pytest run