### PR TITLE
fix(TSTNG-46): return 204 instead of 404 when deleting non-existent c…

### DIFF
--- a/DELETE_CATEGORY_FIX.md
+++ b/DELETE_CATEGORY_FIX.md
@@ -1,0 +1,69 @@
+# DELETE Category API - Idempotency Fix
+
+## Summary
+Fixed the DELETE category endpoint to be idempotent, returning HTTP 204 No Content whether or not the category exists.
+
+## Changes Made
+
+### 1. Added DELETE endpoint to `controllers/category_controller.py`
+- **Route**: `DELETE /categories/{category_id}`
+- **Status Code**: `204 No Content`
+- **Behavior**: 
+  - If category exists: deletes it and returns 204
+  - If category does not exist: still returns 204 (idempotent)
+  - No HTTPException thrown for missing resource
+- **Authorization**: Requires staff or owner role
+
+### 2. Updated tests in `tests/unit/test_category_controller.py`
+Added two new test cases:
+
+- **test_delete_category_existing_returns_204**: 
+  - Tests deletion of an existing category
+  - Verifies the category is deleted from DB
+  - Verifies response is None (translates to 204)
+
+- **test_delete_category_nonexistent_returns_204**:
+  - Tests deletion of non-existent category
+  - Verifies no deletion attempt is made
+  - Verifies response is still None (204)
+  - Ensures idempotency
+
+## Implementation Details
+
+```python
+@router.delete("/{category_id}", status_code=204)
+def delete_category(
+    category_id: UUID,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    require_roles(current_user, ["staff", "owner"])
+
+    category = (
+        db.query(Category)
+        .filter(Category.id == category_id)
+        .first()
+    )
+
+    if category:
+        db.delete(category)
+        db.commit()
+
+    return None
+```
+
+## Compliance with REST Standards
+✅ DELETE is now idempotent (RFC 7231)
+✅ Repeated calls return the same status code (204)
+✅ No client-side error handling required for missing resources
+✅ Aligns with best practices (e.g., AWS, Google Cloud APIs)
+
+## Testing
+Run tests with:
+```bash
+pytest tests/unit/test_category_controller.py -v
+```
+
+Expected results:
+- All 5 tests pass (3 original + 2 new)
+- New tests specifically verify idempotency behavior

--- a/controllers/category_controller.py
+++ b/controllers/category_controller.py
@@ -62,3 +62,23 @@ def list_categories(
         .order_by(Category.name)
         .all()
     )
+
+@router.delete("/{category_id}", status_code=204)
+def delete_category(
+    category_id: UUID,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    require_roles(current_user, ["staff", "owner"])
+
+    category = (
+        db.query(Category)
+        .filter(Category.id == category_id)
+        .first()
+    )
+
+    if category:
+        db.delete(category)
+        db.commit()
+
+    return None

--- a/tests/unit/test_category_controller.py
+++ b/tests/unit/test_category_controller.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
-from controllers.category_controller import create_category, list_categories
+from controllers.category_controller import create_category, list_categories, delete_category
 from models.category import Category
 from schemas.category_schema import CategoryCreate
 
@@ -34,6 +34,7 @@ class DBStub:
         self.added = []
         self.committed = False
         self.refreshed = []
+        self.deleted = []
 
     def query(self, model):
         if model is Category and self.existing is not None:
@@ -50,6 +51,9 @@ class DBStub:
 
     def refresh(self, instance):
         self.refreshed.append(instance)
+
+    def delete(self, instance):
+        self.deleted.append(instance)
 
 
 def test_create_category_trims_name_and_persists():
@@ -91,3 +95,34 @@ def test_list_categories_returns_ordered_collection():
     result = list_categories(restaurant_id=uuid.uuid4(), db=db)
 
     assert result == categories
+
+
+def test_delete_category_existing_returns_204():
+    existing_category = SimpleNamespace(id=uuid.uuid4())
+    db = DBStub(existing=existing_category)
+    user = SimpleNamespace(role="owner")
+
+    result = delete_category(
+        category_id=existing_category.id,
+        db=db,
+        current_user=user,
+    )
+
+    assert result is None
+    assert db.deleted
+    assert db.committed
+
+
+def test_delete_category_nonexistent_returns_204():
+    db = DBStub(existing=None)
+    user = SimpleNamespace(role="owner")
+
+    result = delete_category(
+        category_id=uuid.uuid4(),
+        db=db,
+        current_user=user,
+    )
+
+    assert result is None
+    assert not db.deleted
+    assert not db.committed


### PR DESCRIPTION
## Description
Fix issue where DELETE /categories/{id} returns 404 when category does not exist.

## Changes
- Make DELETE endpoint idempotent
- Return 204 No Content instead of 404 when category not found
- Only perform delete when category exists
- No exception thrown for missing resource

## Testing
- DELETE existing category → returns 204
- DELETE non-existing category → returns 204
- All related unit tests updated and passing

## Notes
- Aligns with RESTful best practices (idempotent DELETE)